### PR TITLE
Add Linter to webpack CLI output

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "^4.10.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",
+    "eslint-loader": "^1.9.0",
     "webpack-dev-server": "^2.9.3"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,15 @@ const config = {
   module: {
     rules: [
       {
+        test: /\.js$/,
+        enforce: "pre",
+        exclude: /node_modules/,
+        loader: 'eslint-loader',
+        options: {
+          emitWarning: true // don't fail the build for linting errors
+        },
+      },
+      {
         test: /\.js$/, // Check for all js files
         exclude: /node_modules/,
         use: [{


### PR DESCRIPTION
Just a nice-to-have feature, this adds the output of the linter to the webpack process.

Is especially nice for projects where people may not know how to integrate a linter into their editor.